### PR TITLE
test_micro_stack: form l2 link

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,6 +26,7 @@ install:
       libvirt0 qemu-system-x86
       qemu-kvm
       qemu-utils
+      mininet
     - sudo touch /srv/virt_pid
     - >
       sudo libvirtd --pid-file /srv/virt_pid
@@ -38,9 +39,11 @@ jobs:
     include:
         - stage: "testing"
           script:
+              - sudo ${HOST_SOFT_RESIDE}/infra/network.py
               - > 
                 docker run
                 --privileged
+                --network=host
                 -it
                 -e SOFT_RESIDE="${RUNNER_SOFT_RESIDE}"
                 -v "${HOST_POOL_DIR}":"${HOST_POOL_DIR}"

--- a/testing/infra/machines.yml
+++ b/testing/infra/machines.yml
@@ -17,9 +17,17 @@ micro_fedora:
 
 source_vm:
   profile: micro_fedora 
+  nets:
+      - name: ovs_1
+        nic: ovs_eth 
+        ovs: true
 
 sink_vm:
   profile: micro_fedora 
+  nets:
+      - name: ovs_2
+        nic: ovs_eth 
+        ovs: true
 
 local:
     type: kvm

--- a/testing/infra/network.py
+++ b/testing/infra/network.py
@@ -1,0 +1,21 @@
+#!/usr/bin/python
+
+from mininet.net import Mininet
+from mininet.node import Controller
+from mininet.link import TCLink
+from mininet.log import info, setLogLevel
+
+setLogLevel('info')
+
+net = Mininet(controller=Controller)
+
+info('*** Adding switches\n')
+ovs_1 = net.addSwitch('ovs_1')
+ovs_2 = net.addSwitch('ovs_2')
+
+info('*** Creating emulation link\n')
+net.addLink(ovs_1, ovs_2,
+            cls=TCLink, delay='100ms', bw=1, loss=2)
+
+info('*** Starting network\n')
+net.start()


### PR DESCRIPTION
Least convoluted way to set up the emulation focus link by tapping into
mininet abstraction, which bases on ovs/openflow/TCnetem itself.