### PR TITLE
cli: refine examples run

### DIFF
--- a/examples/network.yml
+++ b/examples/network.yml
@@ -20,14 +20,14 @@ breeder:
               lower: 4096
               upper: 6291456
   run:
-    bounds:
-      iterations:
-        min: 10
-        max: 1000
-      timing:
-        # start: 1m
-        end: 10d
-        interval: 60
+    parallel: 3
+    iterations:
+      min: 10
+      max: 1000
+    timing:
+      # start: 1m
+      end: 10d
+      interval: 60
   recon:
     # prometheus:
     prober:


### PR DESCRIPTION
Drop bounds and flatten into run.  Introduce parallel flag for sharding
up of problems to parallely running breeder instances.