### PR TITLE
API controller generated breeder dags

### DIFF
--- a/api/maskfile.md
+++ b/api/maskfile.md
@@ -48,4 +48,5 @@ docker run --rm -v "${MASKFILE_DIR}:/local" openapitools/openapi-generator-cli g
 cp "${MASKFILE_DIR}"/controller.py ./flask/openapi_server/controllers/controller.py
 
 echo "apache-airflow-client == 2.3.0" >> ./flask/requirements.txt
+echo "Jinja2 == 3.1.2" >> ./flask/requirements.txt
 ~~~

--- a/breeder/linux_network_stack/root_dag.py
+++ b/breeder/linux_network_stack/root_dag.py
@@ -57,7 +57,7 @@ DEFAULTS = {
     }
 
 
-def create_dag(dag_id):
+def create_dag(dag_id, config):
 
     dag = DAG(dag_id,
               default_args=DEFAULTS,
@@ -69,7 +69,7 @@ def create_dag(dag_id):
         dump_config = BashOperator(
             task_id='print_config',
             bash_command='echo ${config}',
-            env={"config": '{{ dag_run.conf }}'},
+            env={"config": config},
             dag=net_dag,
         )
 
@@ -168,5 +168,6 @@ def create_dag(dag_id):
 
     return dag
 
+config = {{ breeder }}
 dag_id = 'linux_network_stack_breeder'
-globals()[dag_id] = create_dag(dag_id)
+globals()[dag_id] = create_dag(dag_id, config)

--- a/breeder/linux_network_stack/root_dag.py
+++ b/breeder/linux_network_stack/root_dag.py
@@ -19,6 +19,8 @@
 
 from airflow import DAG
 from airflow.operators.bash_operator import BashOperator
+from airflow.operators.dagrun_operator import TriggerDagRunOperator
+from airflow.operators.empty import EmptyOperator
 from airflow.contrib.operators.ssh_operator import SSHOperator
 from airflow.contrib.hooks.ssh_hook import SSHHook
 from airflow.models import Variable
@@ -32,6 +34,8 @@ from distributed import Client, wait
 from prometheus_api_client import PrometheusConnect, MetricsList, Metric
 from prometheus_api_client.utils import parse_datetime
 from datetime import timedelta
+
+from airflow.decorators import task
 
 DEFAULTS = {
     'owner': 'airflow',
@@ -145,7 +149,7 @@ def create_dag(dag_id, config):
         )
 
         @task.branch(task_id="stopping_decision_step")
-        def stopping_decision(ti):
+        def stopping_decision():
             def is_stop_criteria_reached():
                 return True
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -33,8 +33,8 @@ services:
         # on sequencial executor and local sqlite
         entrypoint: bash -c "airflow db init; airflow users create -u airflow -p airflow -r Admin -f airflow -l airflow -e airflow; (airflow scheduler &); airflow webserver"
         volumes:
-            - ./breeder/linux_network_stack/:/opt/airflow/dags
             - ./testing/infra/credentials/ssh/:/opt/airflow/credentials/
+            - ./breeder/dags:/opt/airflow/dags/
         ports:
             - 127.0.0.1:8080:8080
     api:
@@ -44,6 +44,9 @@ services:
         restart: always
         environment:
           - AIRFLOW__URL=http://control_loop:8080
+        volumes:
+            - ./breeder/linux_network_stack/:/usr/src/app/openapi_server/templates/
+            - ./breeder/dags:/usr/src/app/openapi_server/dags/
         ports:
           - 127.0.0.1:9000:8080
     # for optuna parallel metaheuristics execution on dask


### PR DESCRIPTION
Have the API generate the dags to be ran by configuration passed from the clients.

Many tasks have limited templating capabilities. By generating the dag, we gain most flexibility across task operator type. We can even completely rule all hindering limitations out.

Further, there are godon parameters deciding about the overall outline of a dag, like parallelization of tasks. Whereas it's partly feasible with builtin airflow operators or other tricks, that airflow only way is not comparable to the full might of an overall generation. Hence, it's simplifying the implementation of the variadic dags required by the godon breeders.

