### PR TITLE
config space indendent exploration with sharding

### DIFF
--- a/breeder/linux_network_stack/root_dag.py
+++ b/breeder/linux_network_stack/root_dag.py
@@ -92,6 +92,7 @@ config = {{ breeder }}
 parallel_runs = config.get('run').get('parallel')
 targets = config.get('effectuation').get('targets')
 dag_name = config.get('name')
+is_cooperative = config.get('cooperation').get('active')
 
 for target in targets:
     identifier = str(abs(hash(target.get('address'))))[0:6]

--- a/breeder/linux_network_stack/root_dag.py
+++ b/breeder/linux_network_stack/root_dag.py
@@ -47,6 +47,7 @@ import sys
 import random
 import logging
 import json
+import copy
 
 
 task_logger = logging.getLogger("airflow.task")
@@ -94,9 +95,39 @@ targets = config.get('effectuation').get('targets')
 dag_name = config.get('name')
 is_cooperative = config.get('cooperation').get('active')
 
+target_id = 0
+
+def determine_config_shard(run_id=None,
+                           target_id=None,
+                           config=None,
+                           targets_count=0,
+                           parallel_runs_count=0):
+
+    config_result = copy.deepcopy(config)
+    settings_space = config_result.get('settings').get('sysctl')
+
+    for setting in settings_space.items():
+        upper = setting.get('constraints').get('upper')
+        lower = setting.get('constraints').get('lower')
+
+        delta = abs(upper - lower)
+
+        shard_size = delta / targets_count * parallel_runs_count
+
+        setting['constraints']['lower'] = lower + shard_size * (run_id + target_id)
+
+    config_result['settings']['sysctl'] = settings_space
+
+    return config_result
+
+
 for target in targets:
     identifier = str(abs(hash(target.get('address'))))[0:6]
     for run_id in range(0, parallel_runs):
         dag_id = f'{dag_name}_{run_id}'
+        if not is_cooperative:
+            config = determine_config_shard()
         globals()[f'{dag_id}_optimization_{identifier}'] = create_optimization_dag(f'{dag_id}_optimization_{identifier}', config, identifier)
         globals()[f'{dag_id}_target_{identifier}'] = create_target_interaction_dag(f'{dag_id}_target_interaction_{identifier}', config, target, identifier)
+
+    target_id += 1

--- a/examples/network.yml
+++ b/examples/network.yml
@@ -40,6 +40,7 @@ breeder:
       end: 10d
       interval: 60
   cooperation:
+    active: true
     consolidation:
       probability: 0.8
   recon:


### PR DESCRIPTION
Config space sharding makes mostly sense for indepenently exploring breeder dags so far.

That's because in the cooperative exploration, sharding is more of a optimization of the setting sampling process. The individual dags are either way not retrying synchronized, already exploring setting sub-spaces.

For the idepently exploring dags sharding config space is a must to achieve any tangible results timely.