### PR TITLE
stabilize recon query interaction

### DIFF
--- a/breeder/linux_network_stack/effectuation.py
+++ b/breeder/linux_network_stack/effectuation.py
@@ -93,7 +93,9 @@ def create_target_interaction_dag(dag_id, config, target, identifier):
         @dag.task(task_id="recon_step")
         def run_reconnaissance():
             task_logger.debug("Entering")
-            prom_conn = PrometheusConnect(url=PROMETHEUS_URL, disable_ssl=True)
+            prom_conn = PrometheusConnect(url=PROMETHEUS_URL,
+                                          retry=urllib3.util.retry.Retry(total=3, raise_on_status=True, backoff_factor=0.5),
+                                          disable_ssl=True)
 
             start_time = parse_datetime("2m")
             end_time = parse_datetime("now")

--- a/breeder/linux_network_stack/root_dag.py
+++ b/breeder/linux_network_stack/root_dag.py
@@ -41,6 +41,7 @@ from datetime import timedelta
 import asyncio
 
 import pals
+import urllib3
 
 import nats
 import time

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,4 @@ nats-py == 2.2.0
 SQLAlchemy == 2.0.20
 psycopg2-binary == 2.9.7
 PALs == 0.3.5
+urllib3 == 2.0.4


### PR DESCRIPTION
We want to retry in case of any form of oddity in the interaction with the prometheus service.