### PR TITLE
add meta param - strict_validation

### DIFF
--- a/examples/network.yml
+++ b/examples/network.yml
@@ -14,6 +14,7 @@
 # Config format version - independent from godon software version
 meta:
   configVersion: "0.3"
+  strict_validation: false  # Allow unknown parameters with warnings (permissive mode)
 
 # Breeder worker configuration
 breeder:


### PR DESCRIPTION
Giving client the liberty to choose if they want to use settings not covered in the breeder setting registry.

Non strict will only emit a warning then.